### PR TITLE
Check if a job was scheduled before

### DIFF
--- a/gocron.go
+++ b/gocron.go
@@ -449,6 +449,16 @@ func (s *Scheduler) Remove(j interface{}) {
 	s.size = s.size - 1
 }
 
+// Check if specific job j was already added
+func (s *Scheduler) Scheduled(j interface{}) bool {
+	for _, job := range s.jobs {
+		if job.jobFunc == getFunctionName(j) {
+			return true
+		}
+	}
+	return false
+}
+
 // Delete all scheduled jobs
 func (s *Scheduler) Clear() {
 	for i := 0; i < s.size; i++ {
@@ -526,6 +536,16 @@ func Clear() {
 // Remove
 func Remove(j interface{}) {
 	defaultScheduler.Remove(j)
+}
+
+// Check if specific job j was already added
+func Scheduled(j interface{}) bool {
+	for _, job := range defaultScheduler.jobs {
+		if job.jobFunc == getFunctionName(j) {
+			return true
+		}
+	}
+	return false
 }
 
 // NextRun gets the next running time

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -2,9 +2,9 @@
 package gocron
 
 import (
+	"fmt"
 	"testing"
 	"time"
-	"fmt"
 )
 
 var err = 1
@@ -22,4 +22,12 @@ func TestSecond(*testing.T) {
 	defaultScheduler.Every(1).Second().Do(taskWithParams, 1, "hello")
 	defaultScheduler.Start()
 	time.Sleep(10 * time.Second)
+}
+
+func TestScheduled(t *testing.T) {
+	n := NewScheduler()
+	n.Every(1).Second().Do(task)
+	if !n.Scheduled(task) {
+		t.Fatal("Task was scheduled but function couldn't found it")
+	}
 }


### PR DESCRIPTION
This is useful when you need to know if a task should be scheduled or not based on the fact that it is already scheduled (or not)
