### PR TITLE
make jobs run asynchronously to the scheduler

### DIFF
--- a/gocron.go
+++ b/gocron.go
@@ -86,6 +86,7 @@ func (j *Job) shouldRun() bool {
 
 //Run the job and immdiately reschedulei it
 func (j *Job) run() (result []reflect.Value, err error) {
+	t := time.Now()
 	f := reflect.ValueOf(j.funcs[j.jobFunc])
 	params := j.fparams[j.jobFunc]
 	if len(params) != f.Type().NumIn() {
@@ -97,7 +98,7 @@ func (j *Job) run() (result []reflect.Value, err error) {
 		in[k] = reflect.ValueOf(param)
 	}
 	go f.Call(in)
-	j.lastRun = time.Now()
+	j.lastRun = t
 	j.scheduleNextRun()
 	return
 }

--- a/gocron.go
+++ b/gocron.go
@@ -96,7 +96,7 @@ func (j *Job) run() (result []reflect.Value, err error) {
 	for k, param := range params {
 		in[k] = reflect.ValueOf(param)
 	}
-	result = f.Call(in)
+	go f.Call(in)
 	j.lastRun = time.Now()
 	j.scheduleNextRun()
 	return


### PR DESCRIPTION
Cron is a scheduling agent; it does not care when the scheduled job finishes processing. If a long running job is still running at the time of the next scheduled run, it is the responsibility of the job's maintainer to ensure that such a situation is handled appropriately.

Having jobs run synchronously to the scheduling, breaks how Cron works.