### PR TITLE
Fix for https://github.com/jasonlvhit/gocron/issues/23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ _testmain.go
 
 *.exe
 *.test
+
+# IDE project files
+.idea

--- a/gocron.go
+++ b/gocron.go
@@ -86,12 +86,12 @@ func (j *Job) shouldRun() bool {
 	return time.Now().After(j.nextRun)
 }
 
-//Run the job and immdiately reschedulei it
+//Run the job and immediately reschedule it
 func (j *Job) run() (result []reflect.Value, err error) {
 	f := reflect.ValueOf(j.funcs[j.jobFunc])
 	params := j.fparams[j.jobFunc]
 	if len(params) != f.Type().NumIn() {
-		err = errors.New("The number of param is not adapted.")
+		err = errors.New("the number of param is not adapted")
 		return
 	}
 	in := make([]reflect.Value, len(params))
@@ -104,7 +104,7 @@ func (j *Job) run() (result []reflect.Value, err error) {
 	return
 }
 
-// for given function fn , get the name of funciton.
+// for given function fn, get the name of function.
 func getFunctionName(fn interface{}) string {
 	return runtime.FuncForPC(reflect.ValueOf((fn)).Pointer()).Name()
 }
@@ -167,7 +167,7 @@ func (j *Job) At(t string) *Job {
 			j.lastRun = time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day()-1, hour, min, 0, 0, loc)
 		}
 	} else if j.unit == "weeks" {
-		if time.Now().After(mock) {
+		if j.startDay != time.Now().Weekday() || (time.Now().After(mock) && j.startDay == time.Now().Weekday()) {
 			i := mock.Weekday() - j.startDay
 			if i < 0 {
 				i = 7 + i

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -23,6 +23,61 @@ func TestSecond(*testing.T) {
 	time.Sleep(10 * time.Second)
 }
 
+// This is a basic test for the issue described here: https://github.com/jasonlvhit/gocron/issues/23
+func TestScheduler_Weekdays(t *testing.T) {
+	scheduler := NewScheduler()
+
+	job1 := scheduler.Every(1).Monday().At("23:59")
+	job2 := scheduler.Every(1).Wednesday().At("23:59")
+	job1.Do(task)
+	job2.Do(task)
+	t.Logf("job1 scheduled for %s", job1.NextScheduledTime())
+	t.Logf("job2 scheduled for %s", job2.NextScheduledTime())
+	if job1.NextScheduledTime() == job2.NextScheduledTime() {
+		t.Fail()
+		t.Logf("Two jobs scheduled at the same time on two different weekdays should never run at the same time.[job1: %s; job2: %s]", job1.NextScheduledTime(), job2.NextScheduledTime())
+	}
+}
+
+// This ensures that if you schedule a job for today's weekday, but the time is already passed, it will be scheduled for
+// next week at the requested time.
+func TestScheduler_WeekdaysTodayAfter(t *testing.T) {
+	scheduler := NewScheduler()
+
+	now := time.Now()
+	timeToSchedule := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute()-1, 0, 0, time.Local)
+
+	job := callTodaysWeekday(scheduler.Every(1)).At(fmt.Sprintf("%02d:%02d", timeToSchedule.Hour(), timeToSchedule.Minute()))
+	job.Do(task)
+	t.Logf("job is scheduled for %s", job.NextScheduledTime())
+	if job.NextScheduledTime().Weekday() != timeToSchedule.Weekday() {
+		t.Fail()
+		t.Logf("Job scheduled for current weekday for earlier time, should still be scheduled for current weekday (but next week)")
+	}
+	nextWeek := time.Date(now.Year(), now.Month(), now.Day()+7, now.Hour(), now.Minute()-1, 0, 0, time.Local)
+	if !job.NextScheduledTime().Equal(nextWeek) {
+		t.Fail()
+		t.Logf("Job should be scheduled for the correct time next week.")
+	}
+}
+
+// This is to ensure that if you schedule a job for today's weekday, and the time hasn't yet passed, the next run time
+// will be scheduled for today.
+func TestScheduler_WeekdaysTodayBefore(t *testing.T) {
+	scheduler := NewScheduler()
+
+	now := time.Now()
+	timeToSchedule := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute()+1, 0, 0, time.Local)
+
+	job := callTodaysWeekday(scheduler.Every(1)).At(fmt.Sprintf("%02d:%02d", timeToSchedule.Hour(), timeToSchedule.Minute()))
+	job.Do(task)
+	t.Logf("job is scheduled for %s", job.NextScheduledTime())
+	if !job.NextScheduledTime().Equal(timeToSchedule) {
+		t.Fail()
+		t.Logf("Job should be run today, at the set time.")
+	}
+}
+
 func Test_formatTime(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -89,4 +144,18 @@ func Test_formatTime(t *testing.T) {
 			}
 		})
 	}
+}
+
+// utility function for testing the weekday functions *on* the current weekday.
+func callTodaysWeekday(job *Job) *Job {
+	switch time.Now().Weekday() {
+	case 0: job.Sunday()
+	case 1: job.Monday()
+	case 2: job.Tuesday()
+	case 3: job.Wednesday()
+	case 4: job.Thursday()
+	case 5: job.Friday()
+	case 6: job.Saturday()
+	}
+	return job
 }


### PR DESCRIPTION
where scheduling jobs on several weekdays will result in all jobs being run at the same time/day. Added a test for this, and preemptive tests for possible edge cases with weekday functions, mostly to ensure I didn't break anything with my fix.