### PR TITLE
Locking a task to run only one time at any given moment

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ func main() {
 
 and full test cases and [document](http://godoc.org/github.com/jasonlvhit/gocron) will be coming soon.
 
+If you need to prevent a job from running at the same time from multiple cron instances (like running a cron app from multiple servers),
+you can provide a [Locker implementation](example/lock.go) and lock the required jobs.
+
+```go
+gocron.SetLocker(lockerImplementation)
+gocron.Every(1).Hour().Lock().Do(task)
+```
+
 Once again, thanks to the great works of Ruby clockwork and Python schedule package. BSD license is used, see the file License for detail.
 
 Have fun!

--- a/example/lock.go
+++ b/example/lock.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/jasonlvhit/gocron"
+
+	"github.com/go-redis/redis"
+)
+
+// Run a Redis instance with Docker: docker run --rm -tid -p 6379:6379 redis:alpine
+
+func lockedTask(name string) {
+	fmt.Printf("Hello, %s!\n", name)
+
+	t := time.NewTicker(time.Millisecond * 100)
+	c := make(chan struct{})
+	time.AfterFunc(time.Second*5, func() {
+		close(c)
+	})
+
+	for {
+		select {
+		case <-t.C:
+			fmt.Print(".")
+		case <-c:
+			fmt.Println()
+			return
+		}
+	}
+}
+
+// locker implementation with Redis
+type locker struct {
+	cache *redis.Client
+}
+
+func (s *locker) Lock(key string) (success bool, err error) {
+	res, err := s.cache.SetNX(key, time.Now().String(), time.Second*15).Result()
+	if err != nil {
+		return false, err
+	}
+	return res, nil
+}
+
+func (s *locker) Unlock(key string) error {
+	return s.cache.Del(key).Err()
+}
+
+// Run the example in different terminals,
+// passing a different name parameter to each
+func main() {
+	// Get a locker
+	l := &locker{
+		redis.NewClient(&redis.Options{
+			Addr: "localhost:6379",
+		}),
+	}
+
+	// Make locker available for the cron jobs
+	gocron.SetLocker(l)
+
+	arg := "Some Name"
+	args := os.Args[1:]
+	if len(args) > 0 {
+		arg = args[0]
+	}
+
+	gocron.Every(1).Second().Lock().Do(lockedTask, arg)
+	<-gocron.Start()
+}

--- a/gocron.go
+++ b/gocron.go
@@ -80,7 +80,7 @@ func NewJob(interval uint64) *Job {
 		time.Unix(0, 0),
 		time.Sunday,
 		make(map[string]interface{}),
- 		make(map[string][]interface{}),
+		make(map[string][]interface{}),
 		false,
 	}
 }
@@ -94,7 +94,7 @@ func (j *Job) shouldRun() bool {
 func (j *Job) run() (result []reflect.Value, err error) {
 	if j.lock {
 		if locker == nil {
-			err = fmt.Errorf("Trying to lock %s with nil locker.", j.jobFunc)
+			err = fmt.Errorf("trying to lock %s with nil locker", j.jobFunc)
 			return
 		}
 		key := getFunctionKey(j.jobFunc)

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -2,6 +2,7 @@ package gocron
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -389,4 +390,103 @@ func TestWeekdayAt(t *testing.T) {
 	weekJob.scheduleNextRun()
 	exp = time.Date(now.Year(), now.Month(), now.Day()+1, hour, minute, 0, 0, loc)
 	assertEqualTime(t, weekJob.nextRun, exp)
+}
+
+type lockerMock struct {
+	cache map[string]struct{}
+	l     sync.Mutex
+}
+
+func (l *lockerMock) Lock(key string) (bool, error) {
+	l.l.Lock()
+	defer l.l.Unlock()
+	if _, ok := l.cache[key]; ok {
+		return false, nil
+	}
+	l.cache[key] = struct{}{}
+	return true, nil
+}
+
+func (l *lockerMock) Unlock(key string) error {
+	l.l.Lock()
+	defer l.l.Unlock()
+	delete(l.cache, key)
+	return nil
+}
+
+func TestSetLocker(t *testing.T) {
+	if locker != nil {
+		t.Fail()
+		t.Log("Expected locker to not be set by default")
+	}
+
+	SetLocker(&lockerMock{})
+
+	if locker == nil {
+		t.Fail()
+		t.Log("Expected locker to be set")
+	}
+}
+
+type lockerResult struct {
+	key   string
+	cycle int
+	s, e  time.Time
+}
+
+func TestLocker(t *testing.T) {
+	l := sync.Mutex{}
+
+	result := make([]lockerResult, 0)
+	task := func(key string, i int) {
+		s := time.Now()
+		time.Sleep(time.Millisecond * 1000)
+		e := time.Now()
+		l.Lock()
+		result = append(result, lockerResult{
+			key:   key,
+			cycle: i,
+			s:     s,
+			e:     e,
+		})
+		l.Unlock()
+	}
+
+	SetLocker(&lockerMock{
+		make(map[string]struct{}),
+		sync.Mutex{},
+	})
+
+	for i := 0; i < 50; i++ {
+		s1 := NewScheduler()
+		s1.Every(1).Seconds().Lock().Do(task, "A", i)
+
+		s2 := NewScheduler()
+		s2.Every(1).Seconds().Lock().Do(task, "B", i)
+
+		s3 := NewScheduler()
+		s3.Every(1).Seconds().Lock().Do(task, "C", i)
+
+		stop1 := s1.Start()
+		stop2 := s2.Start()
+		stop3 := s3.Start()
+
+		time.Sleep(time.Millisecond * 1500)
+
+		close(stop1)
+		close(stop2)
+		close(stop3)
+
+		for i := 0; i < len(result)-1; i++ {
+			for j := i + 1; j < len(result); j++ {
+				iBefJ := result[i].s.Before(result[j].s) && result[i].e.Before(result[j].s)
+				jBefI := result[j].s.Before(result[i].s) && result[j].e.Before(result[i].s)
+				if !iBefJ && !jBefI {
+					t.Fatalf("\n2 operations ran concurrently:\n%s\n%d\n%s\n%s\n**********\n%s\n%d\n%s\n%s\n",
+						result[i].key, result[i].cycle, result[i].s, result[i].e,
+						result[j].key, result[j].cycle, result[j].s, result[j].e)
+				}
+			}
+		}
+	}
 }

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -2,7 +2,7 @@ package gocron
 
 import (
 	"fmt"
-  "log"
+	"log"
 	"sync"
 	"testing"
 	"time"


### PR DESCRIPTION
The api now allows the developer to provide a locker implementation which serves as a mutex, preventing a job to be run if it's locked.
It can be used to ensure that the same job is not run from multiple machines at the same time.