### PR TITLE
Add a safe execution method

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ func taskWithParams(a int, b string) {
 func main() {
 	// Do jobs with params
 	gocron.Every(1).Second().Do(taskWithParams, 1, "hello")
+	
+	// Do jobs safely, preventing an unexpected panic from bubbling up
+	gocron.Every(1).Second().DoSafely(taskWithParams, 1, "hello")
 
 	// Do jobs without params
 	gocron.Every(1).Second().Do(task)

--- a/gocron.go
+++ b/gocron.go
@@ -21,6 +21,7 @@ package gocron
 import (
 	"errors"
 	"fmt"
+	"log"
 	"reflect"
 	"runtime"
 	"sort"
@@ -105,6 +106,17 @@ func (j *Job) Do(jobFun interface{}, params ...interface{}) {
 	j.fparams[fname] = params
 	j.jobFunc = fname
 	j.scheduleNextRun()
+}
+
+// DoSafely does the same thing as Do, but logs unexpected panics, instead of unwinding them up the chain
+func (j *Job) DoSafely(jobFun interface{}, params ...interface{}) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Printf("Internal panic occurred: %s", err)
+		}
+	}()
+
+	j.Do(jobFun, params)
 }
 
 func formatTime(t string) (hour, min int, err error) {


### PR DESCRIPTION
`DoSafely` makes sure that unexpected panics are not bubbling up the call chain. This can prevent from some nasty errors that cause the entire app to crash

Refers to issue #82 