### PR TITLE
Fix sort order for Jobs (Unix seconds vs Seconds)

### DIFF
--- a/gocron.go
+++ b/gocron.go
@@ -380,7 +380,7 @@ func (s *Scheduler) Swap(i, j int) {
 }
 
 func (s *Scheduler) Less(i, j int) bool {
-	return s.jobs[j].nextRun.Second() >= s.jobs[i].nextRun.Second()
+	return s.jobs[j].nextRun.Unix() >= s.jobs[i].nextRun.Unix()
 }
 
 // NewScheduler creates a new scheduler


### PR DESCRIPTION
This fixes the issue introduced in https://github.com/jasonlvhit/gocron/commit/c290bc117e069bf6f018091823fadb69bec01b43

You can easily see the order issue with:

	gocron.Every(5).Seconds().Do(hello, "5s")
	gocron.Every(1).Day().At("4:00").Do(hello, "1d")

The current code will sort the "1d" call to the top every time and only run the "5s" call once a day.