### PR TITLE
Add ability to retrieve all jobs from scheduler

### DIFF
--- a/gocron.go
+++ b/gocron.go
@@ -161,6 +161,10 @@ func (j *Job) DoSafely(jobFun interface{}, params ...interface{}) {
 	j.Do(jobFun, params)
 }
 
+func Jobs() []*Job {
+	return defaultScheduler.Jobs()
+}
+
 func formatTime(t string) (hour, min int, err error) {
 	var er = errors.New("time format error")
 	ts := strings.Split(t, ":")
@@ -369,6 +373,10 @@ func (j *Job) Lock() *Job {
 type Scheduler struct {
 	jobs [MAXJOBNUM]*Job // Array store jobs
 	size int             // Size of jobs which jobs holding.
+}
+
+func (s *Scheduler) Jobs() []*Job {
+	return s.jobs[:s.size]
 }
 
 func (s *Scheduler) Len() int {

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -2,11 +2,12 @@ package gocron
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"log"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func task() {
@@ -576,4 +577,13 @@ func TestLocker(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestGetAllJobs(t *testing.T) {
+	Every(1).Minute().Do(task)
+	Every(2).Minutes().Do(task)
+	Every(3).Minutes().Do(task)
+	Every(4).Minutes().Do(task)
+	js := Jobs()
+	assert.Len(t, js, 4)
 }


### PR DESCRIPTION
This is useful so you don't have to hold a handle on every job submitted.