### PR TITLE
Allow removing jobs by reference

### DIFF
--- a/gocron_test.go
+++ b/gocron_test.go
@@ -260,6 +260,19 @@ func TestScheduler_Remove(t *testing.T) {
 	assert.Equal(t, 1, scheduler.Len(), "Incorrect number of jobs after removing non-existent job")
 }
 
+func TestScheduler_RemoveByRef(t *testing.T) {
+	scheduler := NewScheduler()
+	job1 := scheduler.Every(1).Minute()
+	job1.Do(task)
+	job2 := scheduler.Every(1).Minute()
+	job2.Do(taskWithParams, 1, "hello")
+
+	assert.Equal(t, 2, scheduler.Len(), "Incorrect number of jobs")
+
+	scheduler.RemoveByRef(job1)
+	assert.ElementsMatch(t, []*Job{job2}, scheduler.Jobs())
+}
+
 func TestTaskAt(t *testing.T) {
 	// Create new scheduler to have clean test env
 	s := NewScheduler()


### PR DESCRIPTION
There are a couple issues with job removal right now:
1. Job functions are not a good way to specify which jobs should be removed. Many jobs rely on the same function and are dynamically generated. Many jobs are specified by lambdas. The semantics of how the removal logic even works is unclear.
1. The implementation leaks memory. If you delete the last job in the job array, it'll reduce the size variable but keep a handle on the pointer to the last job - it'll just never be accessible again. There's no reason to keep that memory used.

This PR makes job removal useful, especially with functions like `scheduler.GetJobs()`.