### PR TITLE
default scheduler state was polluted with other tests, so we reinitia…

### DIFF
--- a/gocron_test.go
+++ b/gocron_test.go
@@ -646,6 +646,7 @@ func TestLocker(t *testing.T) {
 }
 
 func TestGetAllJobs(t *testing.T) {
+	defaultScheduler = NewScheduler()
 	Every(1).Minute().Do(task)
 	Every(2).Minutes().Do(task)
 	Every(3).Minutes().Do(task)


### PR DESCRIPTION
…lize it now