### PR TITLE
go.mod module should be the full path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gocron
+module github.com/jasonlvhit/gocron
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/go-redis/redis v6.15.5+incompatible
-	github.com/jasonlvhit/gocron v0.0.0-20190920192124-d41b6c17ceb8
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/jasonlvhit/gocron v0.0.0-20190920192124-d41b6c17ceb8 h1:B35j/OJnj30WYFRpAR2BEUNVGvhXSn+6aEw93ax80xk=
-github.com/jasonlvhit/gocron v0.0.0-20190920192124-d41b6c17ceb8/go.mod h1:rwi/esz/h+4oWLhbWWK7f6dtmgLzxeZhnwGr7MCsTNk=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
Currently you get this error if you try to use gocron in another project:

```
go get: github.com/jasonlvhit/gocron@v0.0.0-20190920201010-985d45da66c5 updating to
	github.com/jasonlvhit/gocron@v0.0.0-20191006221523-eb4bd7ee9cf2: parsing go.mod:
	module declares its path as: gocron
	       but was required as: github.com/jasonlvhit/gocron
```