### PR TITLE
Fixed: set lastRun before running the function

### DIFF
--- a/gocron.go
+++ b/gocron.go
@@ -125,8 +125,8 @@ func (j *Job) run() (result []reflect.Value, err error) {
 	for k, param := range params {
 		in[k] = reflect.ValueOf(param)
 	}
-	result = f.Call(in)
 	j.lastRun = time.Now()
+	result = f.Call(in)
 	j.scheduleNextRun()
 	return
 }


### PR DESCRIPTION
@Streppel @jchorl  can you folks please review and merge this fix? It's been reported by a couple of people - the current functionality fails to schedule the next job correctly as it uses the time after the job is done instead of the last start time when calculating the next run.