### PR TITLE
add func BeginNow to start job immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ func main() {
 	gocron.Every(1).Monday().At("18:30").Do(task)
 
 	// Begin job immediately upon start
-	gocron.Every(1).Hour().BeginNow().Do(task)
+	gocron.Every(1).Hour().From(gocron.Now()).Do(task)
 
 	// remove, clear and next_run
 	_, time := gocron.NextRun()

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ func main() {
 	gocron.Every(1).Day().At("10:30").Do(task)
 	gocron.Every(1).Monday().At("18:30").Do(task)
 
-	// Do scheduled jobs immediately on start
+	// Begin job immediately upon start
 	gocron.Every(1).Hour().BeginNow().Do(task)
 
 	// remove, clear and next_run

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ func main() {
 	gocron.Every(1).Monday().At("18:30").Do(task)
 
 	// Begin job immediately upon start
-	gocron.Every(1).Hour().From(gocron.NowPlusSecond()).Do(task)
+	gocron.Every(1).Hour().From(gocron.NextTick()).Do(task)
 	
 	// Begin job at a specific date/time
 	t := time.Date(2019, time.November, 10, 15, 0, 0, 0, time.Local)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ func main() {
 	gocron.Every(1).Day().At("10:30").Do(task)
 	gocron.Every(1).Monday().At("18:30").Do(task)
 
+	// Do scheduled jobs immediately on start
+	gocron.Every(1).Hour().BeginNow().Do(task)
+
 	// remove, clear and next_run
 	_, time := gocron.NextRun()
 	fmt.Println(time)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ package main
 
 import (
 	"fmt"
+	"time"
+	
 	"github.com/jasonlvhit/gocron"
 )
 
@@ -58,7 +60,11 @@ func main() {
 	gocron.Every(1).Monday().At("18:30").Do(task)
 
 	// Begin job immediately upon start
-	gocron.Every(1).Hour().From(gocron.Now()).Do(task)
+	gocron.Every(1).Hour().From(gocron.NowPlusSecond()).Do(task)
+	
+	// Begin job at a specific date/time
+	t := time.Date(2019, time.November, 10, 15, 0, 0, 0, time.Local)
+	gocron.Every(1).Hour().From(&t).Do(task)
 
 	// remove, clear and next_run
 	_, time := gocron.NextRun()

--- a/gocron.go
+++ b/gocron.go
@@ -281,7 +281,7 @@ func (j *Job) scheduleNextRun() {
 	if j.lastRun == time.Unix(0, 0) {
 		j.lastRun = now
 	} else if j.lastRun == time.Unix(0, 1) {
-		j.nextRun = now.Add(time.Duration(1) * time.Second)
+		j.nextRun = now
 		return
 	}
 

--- a/gocron.go
+++ b/gocron.go
@@ -280,8 +280,9 @@ func (j *Job) scheduleNextRun() {
 	now := time.Now()
 	if j.lastRun == time.Unix(0, 0) {
 		j.lastRun = now
-	} else if j.lastRun == time.Unix(0, 1) {
-		j.nextRun = now
+	}
+
+	if j.nextRun.After(now) {
 		return
 	}
 
@@ -320,10 +321,16 @@ func (j *Job) mustInterval(i uint64) {
 	}
 }
 
-// BeginNow schedules the next run of the job immediately
-func (j *Job) BeginNow() *Job {
-	j.lastRun = time.Unix(0, 1)
+// From schedules the next run of the job
+func (j *Job) From(t *time.Time) *Job {
+	j.nextRun = *t
 	return j
+}
+
+// NowPlusSecond returns a pointer to time.Now() plus one second
+func NowPlusSecond() *time.Time {
+	now := time.Now().Add(time.Second)
+	return &now
 }
 
 // setUnit sets unit type

--- a/gocron.go
+++ b/gocron.go
@@ -43,6 +43,14 @@ func ChangeLoc(newLocation *time.Location) {
 // MAXJOBNUM max number of jobs, hack it if you need.
 const MAXJOBNUM = 10000
 
+const (
+	seconds = "seconds"
+	minutes = "minutes"
+	hours   = "hours"
+	days    = "days"
+	weeks   = "weeks"
+)
+
 // Job struct keeping information about job
 type Job struct {
 	interval uint64                   // pause interval * unit bettween runs
@@ -166,6 +174,7 @@ func (j *Job) DoSafely(jobFun interface{}, params ...interface{}) {
 	j.Do(jobFun, params)
 }
 
+// Jobs returns the list of Jobs from the defaultScheduler
 func Jobs() []*Job {
 	return defaultScheduler.Jobs()
 }
@@ -247,15 +256,15 @@ func (j *Job) Tags() []string {
 func (j *Job) periodDuration() time.Duration {
 	interval := time.Duration(j.interval)
 	switch j.unit {
-	case "seconds":
+	case seconds:
 		return interval * time.Second
-	case "minutes":
+	case minutes:
 		return interval * time.Minute
-	case "hours":
+	case hours:
 		return interval * time.Hour
-	case "days":
+	case days:
 		return time.Duration(interval * time.Hour * 24)
-	case "weeks":
+	case weeks:
 		return time.Duration(interval * time.Hour * 24 * 7)
 	}
 	panic("unspecified job period") // unspecified period
@@ -271,15 +280,18 @@ func (j *Job) scheduleNextRun() {
 	now := time.Now()
 	if j.lastRun == time.Unix(0, 0) {
 		j.lastRun = now
+	} else if j.lastRun == time.Unix(0, 1) {
+		j.nextRun = now.Add(time.Duration(1) * time.Second)
+		return
 	}
 
 	switch j.unit {
-	case "seconds", "minutes", "hours":
+	case seconds, minutes, hours:
 		j.nextRun = j.lastRun.Add(j.periodDuration())
-	case "days":
+	case days:
 		j.nextRun = j.roundToMidnight(j.lastRun)
 		j.nextRun = j.nextRun.Add(j.atTime)
-	case "weeks":
+	case weeks:
 		j.nextRun = j.roundToMidnight(j.lastRun)
 		dayDiff := int(j.startDay)
 		dayDiff -= int(j.nextRun.Weekday())
@@ -306,6 +318,12 @@ func (j *Job) mustInterval(i uint64) {
 	if j.interval != i {
 		panic(fmt.Sprintf("interval must be %d", i))
 	}
+}
+
+// BeginNow schedules the next run of the job immediately
+func (j *Job) BeginNow() *Job {
+	j.lastRun = time.Unix(0, 1)
+	return j
 }
 
 // setUnit sets unit type
@@ -426,6 +444,7 @@ type Scheduler struct {
 	loc  *time.Location  // Location to use when scheduling jobs with specified times
 }
 
+// Jobs returns the list of Jobs from the Scheduler
 func (s *Scheduler) Jobs() []*Job {
 	return s.jobs[:s.size]
 }
@@ -556,7 +575,7 @@ func (s *Scheduler) removeByCondition(shouldRemove func(*Job) bool) {
 	}
 }
 
-// Check if specific job j was already added
+// Scheduled checks if specific job j was already added
 func (s *Scheduler) Scheduled(j interface{}) bool {
 	for _, job := range s.jobs {
 		if job.jobFunc == getFunctionName(j) {
@@ -596,7 +615,7 @@ func (s *Scheduler) Start() chan bool {
 }
 
 // The following methods are shortcuts for not having to
-// create a Schduler instance
+// create a Scheduler instance
 
 var defaultScheduler = NewScheduler()
 
@@ -645,7 +664,7 @@ func Remove(j interface{}) {
 	defaultScheduler.Remove(j)
 }
 
-// Check if specific job j was already added
+// Scheduled checks if specific job j was already added
 func Scheduled(j interface{}) bool {
 	for _, job := range defaultScheduler.jobs {
 		if job.jobFunc == getFunctionName(j) {

--- a/gocron.go
+++ b/gocron.go
@@ -327,8 +327,8 @@ func (j *Job) From(t *time.Time) *Job {
 	return j
 }
 
-// NowPlusSecond returns a pointer to time.Now() plus one second
-func NowPlusSecond() *time.Time {
+// NextTick returns a pointer to a time that will run at the next tick
+func NextTick() *time.Time {
 	now := time.Now().Add(time.Second)
 	return &now
 }

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -176,16 +176,21 @@ func TestScheduleNextRunLoc(t *testing.T) {
 	assert.Equal(t, tomorrow.Day(), job.NextScheduledTime().UTC().Day())
 }
 
-func TestScheduleNextRunBeginNow(t *testing.T) {
+func TestScheduleNextRunFromNow(t *testing.T) {
 	now := time.Now()
 
 	sched := NewScheduler()
 	sched.ChangeLoc(time.UTC)
 
-	job := sched.Every(1).Hour().BeginNow()
+	job := sched.Every(1).Hour().From(NowPlusSecond())
 	job.Do(task)
 
-	assert.Exactly(t, now.UTC().Second(), job.NextScheduledTime().UTC().Second())
+	next := job.NextScheduledTime()
+	nextRounded := time.Date(next.Year(), next.Month(), next.Day(), next.Hour(), next.Minute(), next.Second(), 0, time.UTC)
+
+	expected := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), now.Second(), 0, time.UTC).Add(time.Second)
+
+	assert.Exactly(t, expected, nextRounded)
 }
 
 // This is to ensure that if you schedule a job for today's weekday, and the time hasn't yet passed, the next run time

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -185,7 +185,7 @@ func TestScheduleNextRunBeginNow(t *testing.T) {
 	job := sched.Every(1).Hour().BeginNow()
 	job.Do(task)
 
-	assert.Exactly(t, now.Add(time.Duration(1)*time.Second).UTC().Second(), job.NextScheduledTime().UTC().Second())
+	assert.Exactly(t, now.UTC().Second(), job.NextScheduledTime().UTC().Second())
 }
 
 // This is to ensure that if you schedule a job for today's weekday, and the time hasn't yet passed, the next run time

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -171,9 +171,21 @@ func TestScheduleNextRunLoc(t *testing.T) {
 	job.Do(task)
 
 	tomorrow := today.AddDate(0, 0, 1)
-	assert.Equal(t, job.NextScheduledTime().UTC().Hour(), 20)
-	assert.Equal(t, job.NextScheduledTime().UTC().Minute(), 44)
-	assert.Equal(t, job.NextScheduledTime().UTC().Day(), tomorrow.Day())
+	assert.Equal(t, 20, job.NextScheduledTime().UTC().Hour())
+	assert.Equal(t, 44, job.NextScheduledTime().UTC().Minute())
+	assert.Equal(t, tomorrow.Day(), job.NextScheduledTime().UTC().Day())
+}
+
+func TestScheduleNextRunBeginNow(t *testing.T) {
+	now := time.Now()
+
+	sched := NewScheduler()
+	sched.ChangeLoc(time.UTC)
+
+	job := sched.Every(1).Hour().BeginNow()
+	job.Do(task)
+
+	assert.Exactly(t, now.Add(time.Duration(1)*time.Second).UTC().Second(), job.NextScheduledTime().UTC().Second())
 }
 
 // This is to ensure that if you schedule a job for today's weekday, and the time hasn't yet passed, the next run time

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -182,7 +182,7 @@ func TestScheduleNextRunFromNow(t *testing.T) {
 	sched := NewScheduler()
 	sched.ChangeLoc(time.UTC)
 
-	job := sched.Every(1).Hour().From(NowPlusSecond())
+	job := sched.Every(1).Hour().From(NextTick())
 	job.Do(task)
 
 	next := job.NextScheduledTime()


### PR DESCRIPTION
- Adds the `BeginNow` function and a test (thoughts on the func name? words are hard...)
    - Usage looks like `gocron.Every(1).Hour().BeginNow().Do(task)`
    - resolves https://github.com/jasonlvhit/gocron/issues/115
- sets const values for seconds, minutes, etc.
- Address golint requirement for exported functions to have comments in the form of `funcName ... description`


