### PR TITLE
add github action to test on go version 12 & 13

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+name: Go Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.12, 1.13]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
This will run tests using go versions 1.12 & 1.13 and for each it will test on Ubuntu, Mac OS and Windows all latest.

closes #122 

@preslavrachev @Streppel 