### PR TITLE
add seconds optionally to At()

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ package main
 import (
 	"fmt"
 	"time"
-	
+
 	"github.com/jasonlvhit/gocron"
 )
 
@@ -40,7 +40,7 @@ func taskWithParams(a int, b string) {
 func main() {
 	// Do jobs with params
 	gocron.Every(1).Second().Do(taskWithParams, 1, "hello")
-	
+
 	// Do jobs safely, preventing an unexpected panic from bubbling up
 	gocron.Every(1).Second().DoSafely(taskWithParams, 1, "hello")
 
@@ -60,13 +60,14 @@ func main() {
 	gocron.Every(1).Monday().Do(task)
 	gocron.Every(1).Thursday().Do(task)
 
-	// Do a job at a specific time - 'hour:min'
+	// Do a job at a specific time - 'hour:min:sec' - seconds optional
 	gocron.Every(1).Day().At("10:30").Do(task)
 	gocron.Every(1).Monday().At("18:30").Do(task)
+	gocron.Every(1).Tuesday().At("18:30:59").Do(task)
 
 	// Begin job immediately upon start
 	gocron.Every(1).Hour().From(gocron.NextTick()).Do(task)
-	
+
 	// Begin job at a specific date/time
 	t := time.Date(2019, time.November, 10, 15, 0, 0, 0, time.Local)
 	gocron.Every(1).Hour().From(&t).Do(task)
@@ -77,7 +78,7 @@ func main() {
 
     // Remove a specific job
 	gocron.Remove(task)
-	
+
 	// Clear all scheduled jobs
 	gocron.Clear()
 
@@ -109,9 +110,9 @@ Looking to contribute? Try to follow these guidelines:
  * For a small change, just send a PR!
  * For bigger changes, please open an issue for discussion before sending a PR.
  * PRs should have: tests, documentation and examples (if it makes sense)
- * You can also contribute by: 
-    * Reporting issues 
-    * Suggesting new features or enhancements 
+ * You can also contribute by:
+    * Reporting issues
+    * Suggesting new features or enhancements
     * Improving/fixing documentation
 
 Have fun!

--- a/gocron.go
+++ b/gocron.go
@@ -185,10 +185,10 @@ func Jobs() []*Job {
 	return defaultScheduler.Jobs()
 }
 
-func formatTime(t string) (hour, min int, err error) {
+func formatTime(t string) (hour, min, sec int, err error) {
 	var er = errors.New("time format error")
 	ts := strings.Split(t, ":")
-	if len(ts) != 2 {
+	if len(ts) < 2 || len(ts) > 3 {
 		err = er
 		return
 	}
@@ -199,24 +199,29 @@ func formatTime(t string) (hour, min int, err error) {
 	if min, err = strconv.Atoi(ts[1]); err != nil {
 		return
 	}
+	if len(ts) == 3 {
+		if sec, err = strconv.Atoi(ts[2]); err != nil {
+			return
+		}
+	}
 
-	if hour < 0 || hour > 23 || min < 0 || min > 59 {
+	if hour < 0 || hour > 23 || min < 0 || min > 59 || sec < 0 || sec > 59 {
 		err = er
 		return
 	}
-	return hour, min, nil
+	return hour, min, sec, nil
 }
 
 // At schedules job at specific time of day
-//	s.Every(1).Day().At("10:30").Do(task)
-//	s.Every(1).Monday().At("10:30").Do(task)
+//	s.Every(1).Day().At("10:30:01").Do(task)
+//	s.Every(1).Monday().At("10:30:01").Do(task)
 func (j *Job) At(t string) *Job {
-	hour, min, err := formatTime(t)
+	hour, min, sec, err := formatTime(t)
 	if err != nil {
 		panic(err)
 	}
 	// save atTime start as duration from midnight
-	j.atTime = time.Duration(hour)*time.Hour + time.Duration(min)*time.Minute
+	j.atTime = time.Duration(hour)*time.Hour + time.Duration(min)*time.Minute + time.Duration(sec)*time.Second
 	return j
 }
 

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -211,6 +211,7 @@ func Test_formatTime(t *testing.T) {
 		args     string
 		wantHour int
 		wantMin  int
+		wantSec  int
 		wantErr  bool
 	}{
 		{
@@ -221,10 +222,11 @@ func Test_formatTime(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name:     "normal",
-			args:     "6:18",
+			name:     "normal_with_second",
+			args:     "6:18:01",
 			wantHour: 6,
 			wantMin:  18,
+			wantSec:  1,
 			wantErr:  false,
 		},
 		{
@@ -250,7 +252,7 @@ func Test_formatTime(t *testing.T) {
 		},
 		{
 			name:     "wrong_format",
-			args:     "19:18:17",
+			args:     "19:18:17:17",
 			wantHour: 0,
 			wantMin:  0,
 			wantErr:  true,
@@ -272,13 +274,18 @@ func Test_formatTime(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotHour, gotMin, err := formatTime(tt.args)
+			gotHour, gotMin, gotSec, err := formatTime(tt.args)
 			if tt.wantErr {
 				assert.NotEqual(t, nil, err, tt.args)
 				return
 			}
 			assert.Equal(t, tt.wantHour, gotHour, tt.args)
 			assert.Equal(t, tt.wantMin, gotMin, tt.args)
+			if tt.wantSec != 0 {
+				assert.Equal(t, tt.wantSec, gotSec)
+			} else {
+				assert.Zero(t, gotSec)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Closes https://github.com/jasonlvhit/gocron/issues/144

Makes the `At()` option take seconds optionally. Defaults to `0` if not set.